### PR TITLE
Fix pre-link script warning by using new noarch syntax, preserve egg file.

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,12 +1,14 @@
 package:
   name: smirff99frosst
-  version: "1.0.4"
+  version: "1.0.5"
 
 source:
     path: ../
 
 build:
-    noarch_python: True
+    noarch: python
+    preserve_egg_dir: True
+    number: 0
     script: python setup.py install
 
 requirements:
@@ -15,6 +17,7 @@ requirements:
         - setuptools
     run:
         - python
+
 about:
   home: https://github.com/open-forcefield-group/smirff99Frosst
   license: MIT

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ This provides the first general-purpose implementation of a Smirks Force Field (
 
 setup(
     name                 = 'smirff99frosst',
-    version              = '1.0.4',
+    version              = '1.0.5',
     description          = 'SMIRNOFF Forcefield parameters',
     long_description     = descr,
     url                  = 'https://github.com/open-forcefield-group/smirff99Frosst',
@@ -26,6 +26,5 @@ setup(
     license              = 'MIT',
     platforms            = ['Linux-64', 'Mac OSX-64', 'Unix-64'],
     packages             = find_packages()+['smirff99frosst'],
-    include_package_data = True,
-    zip_safe             = False
+    include_package_data = True
 )


### PR DESCRIPTION
Resolves issue #28 

The issue appeared to be with using the `noarch_python: True` syntax which appears to be depreciated in favor of `noarch: python`. At least on my end the message has gone away. 

See Anaconda docs on noarch packages: https://www.continuum.io/blog/developer-blog/condas-new-noarch-packages

Another minor change is adding the `preserve_egg_dir: True` line which will keep it in a tidy .egg file. The .ffxml is still accessible from the .egg file, so I think this is the better way to go. 

Bumped the version number to 1.0.5 and updated the package on our condo channel.